### PR TITLE
use current file as base for searching node_modules

### DIFF
--- a/plugin/neomake-local-eslint.vim
+++ b/plugin/neomake-local-eslint.vim
@@ -7,7 +7,7 @@ let g:loaded_neomake_local_npm = 1
 " Navigate up the tree looking for node_module/.bin/{binname}; falling back to
 " `npm bin` directory
 function! GetNpmBin(binname)
-  let dir = getcwd()
+  let dir = expand("%:p:h")
   while ! isdirectory(dir . '/node_modules')
     let dir = fnamemodify(dir, ':h')
     if dir == '/'


### PR DESCRIPTION
instead of using the current working directory (usually the project root).

Works for projects the put their JavaScript sources into a subdirectory
of the project root, e.g.:

```
.
├── app
├── bin
├── client
│   ├── dist
│   ├── node_modules        <- eslint is in here
│   └── src                 <- JS sources here
...
```